### PR TITLE
serializability: Support for Java serialization.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,17 +211,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <inherited>false</inherited>
-                <configuration>
-                    <serverId>ossrh-releases</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <stagingProfileId>af82fa330d4f7</stagingProfileId>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
                 <version>1.11</version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,12 @@
     <artifactId>tcl-regex</artifactId>
     <groupId>com.basistech.tclre</groupId>
     <version>0.10.3-SNAPSHOT</version>
-    <description>Basis java port of the regex engine from  Tcl</description>
+    <packaging>bundle</packaging>
+    <description>Java port of the regex engine from Tcl</description>
     <parent>
-        <groupId>com.simpligility.maven</groupId>
-        <artifactId>progressive-organization-pom</artifactId>
-        <version>1.5.1</version>
+        <groupId>com.basistech</groupId>
+        <artifactId>open-source-parent</artifactId>
+        <version>0.0.4</version>
     </parent>
     <prerequisites>
         <maven>3.0.4</maven>
@@ -55,11 +56,8 @@
             <url>scm:git:git@github.com:basis-technology-corp/tcl-regex-java.git</url>
         </site>
     </distributionManagement>
-    <properties>
-        <maven.version>3.0.4</maven.version>
-    </properties>
     <dependencies>
-      <!-- the order here (hamcrest, hamcrest, mockito) is important. -->
+        <!-- the order here (hamcrest, hamcrest, mockito) is important. -->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
@@ -85,6 +83,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.basistech</groupId>
+            <artifactId>pax-exam-test-composite</artifactId>
+            <version>0.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
             <version>53.1</version>
@@ -102,6 +106,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <scope>compile</scope>
             <version>1.7.5</version>
         </dependency>
         <dependency>
@@ -115,6 +120,12 @@
             <artifactId>args4j</artifactId>
             <version>2.0.26</version>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>5.0.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>
@@ -140,9 +151,65 @@
                         <scmBranch>gh-pages</scmBranch>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.18</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
+            <!-- because we're not dealing any tricky OSGi version
+                 issues, we can just grab our dependencies and filter
+                 down to get our bundles. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <id>copy-bundles</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/bundles</outputDirectory>
+                            <!--
+                              Exclude the ones that are not OSGi
+                              components, plus OSGi itself.
+                          -->
+                            <excludeArtifactIds>fastutil,bndlib,org.osgi.core</excludeArtifactIds>
+                            <excludeGroupIds>org.slf4j</excludeGroupIds>
+                            <includeScope>compile</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.servicemix.tooling</groupId>
+                <artifactId>depends-maven-plugin</artifactId>
+                <version>1.2</version>
+                <executions>
+                    <execution>
+                        <id>generate-depends-file</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>generate-depends-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>com.basistech.tclre</Export-Package>
+                        <Embed-Dependency>fastutil</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -153,30 +220,6 @@
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     <stagingProfileId>af82fa330d4f7</stagingProfileId>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <phase>validate</phase>
-                        <configuration>
-                            <rules>
-                                <requireMavenVersion>
-                                    <version>3.0.4</version>
-                                </requireMavenVersion>
-                                <requireJavaVersion>
-                                    <version>[1.7.0,1.8)</version>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -201,20 +244,23 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18</version>
                 <executions>
                     <execution>
-                        <id>attach-descriptor</id>
                         <goals>
-                            <goal>attach-descriptor</goal>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <java.awt.headless>true</java.awt.headless>
+                                <project.build.directory>${project.build.directory}</project.build.directory>
+                                <project.version>${project.version}</project.version>
+                            </systemPropertyVariables>
+                        </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/basistech/tclre/Cnfa.java
+++ b/src/main/java/com/basistech/tclre/Cnfa.java
@@ -16,66 +16,34 @@
 
 package com.basistech.tclre;
 
+import java.io.Serializable;
+
 /**
  * Compacted (runtime) NFA.
  */
-class Cnfa {
+class Cnfa implements Serializable {
+    static final long serialVersionUID = 1L;
     static final int HASLACONS = 1;
-    int nstates;        /* number of states */
-    int ncolors;        /* number of colors */
-    int flags;
-    int pre;        /* setup state number */
-    int post;       /* teardown state number */
-    short[] bos = new short[2];     /* colors, if any, assigned to BOS and BOL */
-    short[] eos = new short[2];     /* colors, if any, assigned to EOS and EOL */
-    long[] arcs;
+    final int ncolors;        /* number of colors */
+    final int flags;
+    final int pre;        /* setup state number */
+    final int post;       /* teardown state number */
+    final short[] bos;     /* colors, if any, assigned to BOS and BOL */
+    final short[] eos;     /* colors, if any, assigned to EOS and EOL */
+    final long[] arcs;
     // each state is an index of an arc.
-    int[] states;
+    final int[] states;
 
 
-    Cnfa(int nstates,
-         int narcs,
-         int preNo,
-         int postNo, short[] bos,
-         short[] eos, int maxcolors, int flags) {
-
-        this.pre = preNo;
-        this.post = postNo;
-        this.nstates = nstates;
+    Cnfa(int ncolors, int flags, int pre, int post, short[] bos, short[] eos, long[] arcs, int[] states) {
+        this.ncolors = ncolors;
+        this.flags = flags;
+        this.pre = pre;
+        this.post = post;
         this.bos = bos;
         this.eos = eos;
-        this.ncolors = maxcolors;
-        this.flags = flags;
-
-        this.arcs = new long[narcs];
-        this.states = new int[nstates];
-    }
-
-    void dump() {
-        System.out.format("nstates %d\nncolors %d\nflags %x\npre %d\npost %d\nbos [%d, %d]\neos [%d %d]\n",
-            nstates,
-            ncolors,
-            flags,
-            pre,
-            post,
-            bos[0],
-            bos[1],
-            eos[0],
-            eos[1]);
-        System.out.format("    color state\n");
-        for (int x = 0; x < arcs.length; x++) {
-            long arc = arcs[x];
-            System.out.format("%03d %5d %d\n", x, carcColor(arc), carcTarget(arc));
-        }
-        System.out.println();
-    }
-
-    void setState(int index, int arcIndex) {
-        states[index] = arcIndex;
-    }
-
-    void setArc(int index, long arcValue) {
-        arcs[index] = arcValue;
+        this.arcs = arcs;
+        this.states = states;
     }
 
     static long packCarc(short color, int targetState) {
@@ -89,37 +57,4 @@ class Cnfa {
     static int carcTarget(long packed) {
         return (int)packed;
     }
-
-    /**
-     * carcsort - sort compacted-NFA arcs by color
-     * Really dumb algorithm, but if the list is long enough for that to matter,
-     * you're in real trouble anyway.
-     */
-    void carcsort(int first, int last) {
-        int p;
-        int q;
-        long tmp;
-
-        if (last - first <= 1) {
-            return;
-        }
-
-        for (p = first; p <= last; p++) {
-            for (q = p; q <= last; q++) {
-                short pco = carcColor(arcs[p]);
-                short qco = carcColor(arcs[q]);
-                int pto = carcTarget(arcs[p]);
-                int qto = carcTarget(arcs[q]);
-                if (pco > qco || (pco == qco && pto > qto)) {
-                    assert p != q;
-                    tmp = arcs[p];
-                    arcs[p] = arcs[q];
-                    arcs[q] = tmp;
-                }
-            }
-        }
-    }
-
-
-
 }

--- a/src/main/java/com/basistech/tclre/CnfaBuilder.java
+++ b/src/main/java/com/basistech/tclre/CnfaBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014 Basis Technology Corp.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.basistech.tclre;
+
+/**
+ * Mutable builder of immutable CNFA objects.
+ */
+class CnfaBuilder {
+    int ncolors;        /* number of colors */
+    int flags;
+    int pre;        /* setup state number */
+    int post;       /* teardown state number */
+    short[] bos;     /* colors, if any, assigned to BOS and BOL */
+    short[] eos;     /* colors, if any, assigned to EOS and EOL */
+    long[] arcs;
+    // each state is an index of an arc.
+    int[] states;
+
+
+    CnfaBuilder(int nstates,
+         int narcs,
+         int preNo,
+         int postNo,
+         short[] bos,
+         short[] eos,
+         int maxcolors,
+         int flags) {
+
+        this.pre = preNo;
+        this.post = postNo;
+        this.bos = bos;
+        this.eos = eos;
+        this.ncolors = maxcolors;
+        this.flags = flags;
+
+        this.arcs = new long[narcs];
+        this.states = new int[nstates];
+    }
+
+    Cnfa build() {
+        return new Cnfa(ncolors, flags, pre, post, bos, eos, arcs, states);
+    }
+
+    void setState(int index, int arcIndex) {
+        states[index] = arcIndex;
+    }
+
+    void setArc(int index, long arcValue) {
+        arcs[index] = arcValue;
+    }
+
+    static long packCarc(short color, int targetState) {
+        return ((long)color << 32) | targetState;
+    }
+
+
+    /**
+     * carcsort - sort compacted-NFA arcs by color
+     * Really dumb algorithm, but if the list is long enough for that to matter,
+     * you're in real trouble anyway.
+     */
+    void carcsort(int first, int last) {
+        int p;
+        int q;
+        long tmp;
+
+        if (last - first <= 1) {
+            return;
+        }
+
+        for (p = first; p <= last; p++) {
+            for (q = p; q <= last; q++) {
+                short pco = Cnfa.carcColor(arcs[p]);
+                short qco = Cnfa.carcColor(arcs[q]);
+                int pto = Cnfa.carcTarget(arcs[p]);
+                int qto = Cnfa.carcTarget(arcs[q]);
+                if (pco > qco || (pco == qco && pto > qto)) {
+                    assert p != q;
+                    tmp = arcs[p];
+                    arcs[p] = arcs[q];
+                    arcs[q] = tmp;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/basistech/tclre/Compiler.java
+++ b/src/main/java/com/basistech/tclre/Compiler.java
@@ -16,6 +16,7 @@
 
 package com.basistech.tclre;
 
+import java.io.Serializable;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -159,7 +160,6 @@ final class Compiler {
         stop = pattern.length;
         nlcolor = Constants.COLORLESS;
         info = 0;
-        Guts guts = new Guts();
 
         cm = new ColorMap(this);
         nfa = new Nfa(cm);
@@ -220,24 +220,19 @@ final class Compiler {
     /* can sacrifice main NFA now, so use it as work area */
         nfa.optimize();
         makesearch(nfa);
-        guts.search = nfa.compact();
+        Cnfa search = nfa.compact();
 
     /* looks okay, package it up */
         int nsub = subs.size();
-        guts.cm = cm;
-        guts.cflags = cflags;
-        guts.info = info;
-        guts.nsub = nsub;
-        guts.tree = tree;
-        guts.ntree = ntree;
+        SubstringComparator compare;
         if (0 != (cflags & Flags.REG_ICASE)) {
-            guts.compare = new Comparer(true);
+            compare = new Comparer(true);
         } else {
-            guts.compare = new Comparer(false);
+            compare = new Comparer(false);
         }
 
-
-        guts.setupLookaheadConstraints(lacons);
+        Guts guts = new Guts(cflags, info, nsub, new RuntimeSubexpression(tree),
+                search, ntree, cm, compare, lacons);
         return new HsrePattern(new String(pattern, 0, pattern.length), originalFlags, info, nsub, guts);
     }
 
@@ -267,7 +262,8 @@ final class Compiler {
         return subs;
     }
     
-    static class Comparer implements SubstringComparator {
+    static class Comparer implements SubstringComparator, Serializable {
+        static final long serialVersionUID = 1L;
         private final boolean caseInsensitive;
 
         Comparer(boolean caseInsensitive) {

--- a/src/main/java/com/basistech/tclre/Compiler.java
+++ b/src/main/java/com/basistech/tclre/Compiler.java
@@ -236,7 +236,8 @@ final class Compiler {
             guts.compare = new Comparer(false);
         }
 
-        guts.lacons = lacons;
+
+        guts.setupLookaheadConstraints(lacons);
         return new HsrePattern(new String(pattern, 0, pattern.length), originalFlags, info, nsub, guts);
     }
 

--- a/src/main/java/com/basistech/tclre/Dfa.java
+++ b/src/main/java/com/basistech/tclre/Dfa.java
@@ -37,7 +37,7 @@ class Dfa {
     final int nstates;
     final int ncolors; // length of outarc and inchain vectors (really?)
     final Cnfa cnfa;
-    final ColorMap cm;
+    final RuntimeColorMap cm;
     final Runtime hsreMatcher;
 
     Dfa(Runtime hsreMatcher, Cnfa cnfa) {
@@ -52,7 +52,7 @@ class Dfa {
          * to the complexity of the machine, not to the input.
          */
         stateSets = new Object2ObjectOpenHashMap<BitSet, StateSet>();
-        nstates = cnfa.nstates;
+        nstates = cnfa.states.length;
         ncolors = cnfa.ncolors;
     }
 
@@ -63,7 +63,6 @@ class Dfa {
     StateSet initialize(int start) {
         // Discard state sets; reuse would be faster if we kept them,
         // but then we'd need the real cache.
-        //stateSets.clear();
         stateSets.clear();
         StateSet stateSet = new StateSet(nstates, ncolors);
         stateSet.states.set(cnfa.pre, true);

--- a/src/main/java/com/basistech/tclre/Dfa.java
+++ b/src/main/java/com/basistech/tclre/Dfa.java
@@ -207,12 +207,11 @@ class Dfa {
         // compare this to com.basistech.tclre.Nfa.compact(), the LACONS case.
         // that adds a.co to ncolors. So that means that you'd think that the lacons
         // indexing would be related... The 'arc' should have a 'color' which is an index
-        // into lacon.
-        assert n < hsreMatcher.g.lacons.size();
-        Subre sub = hsreMatcher.g.lacons.get(n);
-        Dfa d = new Dfa(hsreMatcher, sub.cnfa);
+        //
+        RuntimeSubexpression subex = hsreMatcher.g.lookaheadConstraintMachine(n);
+        Dfa d = new Dfa(hsreMatcher, subex.machine);
         end = d.longest(cp, hsreMatcher.data.length(), null);
-        return (sub.subno != 0) ? (end != -1) : (end == -1);
+        return (subex.number != 0) ? (end != -1) : (end == -1);
     }
 
     /**

--- a/src/main/java/com/basistech/tclre/Guts.java
+++ b/src/main/java/com/basistech/tclre/Guts.java
@@ -17,37 +17,46 @@
 package com.basistech.tclre;
 
 
+import java.io.Serializable;
 import java.util.List;
 import com.google.common.collect.Lists;
+import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 
 /**
- * Data structures derived from regguts.h.
- * Note that this is built for 16-bit chars.
+ * The bits and pieces that make up a runnable expression. This is immutable.
  */
-class Guts {
-    int cflags;     /* copy of compile flags */
-    long info;      /* copy of re_info */
-    int nsub;       /* copy of re_nsub */
-    Subre tree;
-    Cnfa search;    /* for fast preliminary search */
-    int ntree;
-    ColorMap cm;
-    SubstringComparator compare;
+class Guts implements Serializable {
+    static final long serialVersionUID = 1L;
+
+    final int cflags;     /* copy of compile flags */
+    final long info;      /* copy of re_info */
+    final int nsub;       /* copy of re_nsub */
+    final RuntimeSubexpression tree;
+    final Cnfa search;    /* for fast preliminary search */
+    final int ntree;
+    final RuntimeColorMap cm;
+    final SubstringComparator compare;
 
     private List<RuntimeSubexpression> lookaheadConstraintMachines;
 
-    //TODO: turn this into immutable
-    Guts() {
-    }
-
-    void setupLookaheadConstraints(List<Subre> lacons) {
+    public Guts(int cflags, long info, int nsub, RuntimeSubexpression tree, Cnfa search, int ntree, ColorMap cm, SubstringComparator compare, List<Subre> lacons) {
+        this.cflags = cflags;
+        this.info = info;
+        this.nsub = nsub;
+        this.tree = tree;
+        this.search = search;
+        this.ntree = ntree;
+        // create the sort of color map that we can serialize and share.
+        this.cm = new RuntimeColorMap(cm.tree[0]);
+        this.compare = compare;
         if (lacons != null) {
             lookaheadConstraintMachines = Lists.newArrayList();
             for (Subre subre : lacons) {
                 if (subre == null) {
-                    lookaheadConstraintMachines.add(new RuntimeSubexpression(0, null));
+                    lookaheadConstraintMachines.add(new RuntimeSubexpression());
                 } else {
-                    lookaheadConstraintMachines.add(new RuntimeSubexpression(subre.subno, subre.cnfa));
+                    lookaheadConstraintMachines.add(new RuntimeSubexpression(subre));
                 }
             }
         }

--- a/src/main/java/com/basistech/tclre/Guts.java
+++ b/src/main/java/com/basistech/tclre/Guts.java
@@ -34,9 +34,26 @@ class Guts {
     ColorMap cm;
     SubstringComparator compare;
 
-    List<Subre> lacons; /* lookahead-constraint vector */
+    private List<RuntimeSubexpression> lookaheadConstraintMachines;
 
+    //TODO: turn this into immutable
     Guts() {
-        lacons = Lists.newArrayList();
+    }
+
+    void setupLookaheadConstraints(List<Subre> lacons) {
+        if (lacons != null) {
+            lookaheadConstraintMachines = Lists.newArrayList();
+            for (Subre subre : lacons) {
+                if (subre == null) {
+                    lookaheadConstraintMachines.add(new RuntimeSubexpression(0, null));
+                } else {
+                    lookaheadConstraintMachines.add(new RuntimeSubexpression(subre.subno, subre.cnfa));
+                }
+            }
+        }
+    }
+
+    RuntimeSubexpression lookaheadConstraintMachine(int index) {
+        return lookaheadConstraintMachines.get(index);
     }
 }

--- a/src/main/java/com/basistech/tclre/HsrePattern.java
+++ b/src/main/java/com/basistech/tclre/HsrePattern.java
@@ -16,6 +16,7 @@
 
 package com.basistech.tclre;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.EnumSet;
 
@@ -27,7 +28,8 @@ import com.google.common.base.Objects;
  * @see com.basistech.tclre.RePattern
  * @see com.basistech.tclre.ReMatcher
  */
-public class HsrePattern implements RePattern {
+public class HsrePattern implements RePattern, Serializable {
+    static final long serialVersionUID = 1L;
     final long info;
     final int nsub;       /* number of subexpressions */
     final Guts guts;

--- a/src/main/java/com/basistech/tclre/Nfa.java
+++ b/src/main/java/com/basistech/tclre/Nfa.java
@@ -999,10 +999,10 @@ class Nfa {
         }
 
         int arcIndex = 0;
-        Cnfa cnfa = new Cnfa(stateCount, narcs, pre.no, post.no, bos, eos, cm.maxcolor() + 1, 0);
+        CnfaBuilder cnfaBuilder = new CnfaBuilder(stateCount, narcs, pre.no, post.no, bos, eos, cm.maxcolor() + 1, 0);
         for (State s = states; s != null; s = s.next) {
             assert s.no < stateCount;
-            cnfa.setState(s.no, arcIndex);
+            cnfaBuilder.setState(s.no, arcIndex);
             /* clear and skip flags "arc", by preparing to set arc at index 1 */
             arcIndex++;
             long arcValue;
@@ -1013,34 +1013,34 @@ class Nfa {
                     arcValue = Cnfa.packCarc(a.co, a.to.no);
                     break;
                 case Compiler.LACON:
-                    assert s.no != cnfa.pre;
-                    arcValue = Cnfa.packCarc((short)(cnfa.ncolors + a.co), a.to.no);
-                    cnfa.flags |= Cnfa.HASLACONS;
+                    assert s.no != cnfaBuilder.pre;
+                    arcValue = Cnfa.packCarc((short)(cnfaBuilder.ncolors + a.co), a.to.no);
+                    cnfaBuilder.flags |= Cnfa.HASLACONS;
                     break;
                 default:
                     throw new RuntimeException("Impossible arc");
                 }
-                cnfa.setArc(arcIndex, arcValue);
+                cnfaBuilder.setArc(arcIndex, arcValue);
                 arcIndex++;
             }
-            cnfa.carcsort(first, arcIndex - 1);
-            cnfa.setArc(arcIndex++, Cnfa.packCarc(Constants.COLORLESS, 0));
+            cnfaBuilder.carcsort(first, arcIndex - 1);
+            cnfaBuilder.setArc(arcIndex++, Cnfa.packCarc(Constants.COLORLESS, 0));
         }
 
         assert arcIndex == narcs;
-        assert cnfa.nstates != 0;
+        assert cnfaBuilder.states.length != 0;
 
     /* mark no-progress states */
         for (a = pre.outs; a != null; a = a.outchain) {
-            int ax = cnfa.states[a.to.no];
+            int ax = cnfaBuilder.states[a.to.no];
             // replace color in this arc with '1'.
-            long newArcValue = Cnfa.packCarc((short)1, Cnfa.carcTarget(cnfa.arcs[ax]));
-            cnfa.arcs[ax] = newArcValue;
+            long newArcValue = Cnfa.packCarc((short)1, Cnfa.carcTarget(cnfaBuilder.arcs[ax]));
+            cnfaBuilder.arcs[ax] = newArcValue;
         }
-        arcIndex = cnfa.states[pre.no];
-        long newArcValue = Cnfa.packCarc((short)1, Cnfa.carcTarget(cnfa.arcs[pre.no]));
-        cnfa.arcs[arcIndex] = newArcValue;
+        arcIndex = cnfaBuilder.states[pre.no];
+        long newArcValue = Cnfa.packCarc((short)1, Cnfa.carcTarget(cnfaBuilder.arcs[pre.no]));
+        cnfaBuilder.arcs[arcIndex] = newArcValue;
 
-        return cnfa;
+        return cnfaBuilder.build();
     }
 }

--- a/src/main/java/com/basistech/tclre/RuntimeColorMap.java
+++ b/src/main/java/com/basistech/tclre/RuntimeColorMap.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2014 Basis Technology Corp.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.basistech.tclre;
+
+import it.unimi.dsi.fastutil.chars.Char2ShortArrayMap;
+import it.unimi.dsi.fastutil.chars.Char2ShortMap;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+
+/**
+ * Immutable, sharable, color map.
+ * The ColorMap data structure is a fully-populated map from all possible char values to shorts,
+ * represented in a complex way.
+ * This just uses the obvious array of 2^16 shorts. If we wanted to trade space for time,
+ * we could use an Short2ShortOpenHashMap instead.
+  */
+class RuntimeColorMap implements Serializable {
+    static final long serialVersionUID = 1L;
+    /* A somewhat sparse representation. */
+    private final short[] data;
+
+    /**
+     * Construct over a tree. It is the caller's responsibility to make an immutable copy.
+     * @param colorMapTree -- the tree as built in the ColorMap.
+     */
+    RuntimeColorMap(ColorMap.Tree colorMapTree) {
+        data = new short[Character.MAX_VALUE + 1];
+        for (int x = 0; x < 256; x++) {
+            if (colorMapTree.ptrs[x] != null) {
+                for (int y = 0; y < 256; y++) {
+                    int index = (x * 256) + y;
+                    data[index] = colorMapTree.ptrs[x].ccolor[y];
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieve the color for a character.
+     * @param c
+     * @return
+     */
+    short getcolor(char c) {
+        return data[c];
+    }
+
+    /*
+     * Avoid reading and writing 2^16 shorts by turning it into a sparse data structure.
+     */
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+        Char2ShortMap map = new Char2ShortArrayMap();
+        map.defaultReturnValue((short)0);
+        for (int x = 0; x <= Character.MAX_VALUE; x++) {
+            if (data[x] != 0) {
+                map.put((char)x, data[x]);
+            }
+        }
+        out.writeObject(map);
+    }
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        try {
+            Field dataField = RuntimeColorMap.class.getDeclaredField("data");
+            dataField.setAccessible(true);
+            dataField.set(this, new short[Character.MAX_VALUE + 1]);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        Char2ShortMap map = (Char2ShortMap) in.readObject();
+        for (char c : map.keySet()) {
+            data[c] = map.get(c); // thank goodness that Java doesn't have actual immutable arrays.
+        }
+    }
+}

--- a/src/main/java/com/basistech/tclre/RuntimeSubexpression.java
+++ b/src/main/java/com/basistech/tclre/RuntimeSubexpression.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 Basis Technology Corp.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.basistech.tclre;
+
+/**
+ * Information needed at runtime for a subexpression.
+ */
+final class RuntimeSubexpression {
+    final int number;
+    final Cnfa machine;
+
+    RuntimeSubexpression(int number, Cnfa machine) {
+        this.number = number;
+        this.machine = machine;
+    }
+}

--- a/src/main/java/com/basistech/tclre/RuntimeSubexpression.java
+++ b/src/main/java/com/basistech/tclre/RuntimeSubexpression.java
@@ -15,15 +15,54 @@
  */
 package com.basistech.tclre;
 
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+
+import java.io.Serializable;
+
 /**
  * Information needed at runtime for a subexpression.
  */
-final class RuntimeSubexpression {
+final class RuntimeSubexpression implements Serializable {
+    static final long serialVersionUID = 1L;
     final int number;
     final Cnfa machine;
+    final char op;
+    final RuntimeSubexpression left;
+    final RuntimeSubexpression right;
+    final int flags;
+    final int retry;
+    final int min;
+    final int max;
 
-    RuntimeSubexpression(int number, Cnfa machine) {
-        this.number = number;
-        this.machine = machine;
+    RuntimeSubexpression() {
+        number = -1;
+        machine = null;
+        op = 0;
+        left = null;
+        right = null;
+        flags = 0;
+        retry = 0;
+        this.min = 0;
+        this.max = 0;
+    }
+
+    RuntimeSubexpression(Subre re) {
+        this.number = re.subno;
+        this.op = re.op;
+        this.machine = re.cnfa;
+        this.flags = re.flags;
+        if (re.left == null) {
+            this.left = null;
+        } else {
+            this.left = new RuntimeSubexpression(re.left);
+        }
+        if (re.right == null) {
+            this.right = null;
+        } else {
+            this.right = new RuntimeSubexpression(re.right);
+        }
+        this.retry = re.retry;
+        this.min = re.min;
+        this.max = re.max;
     }
 }

--- a/src/test/java/com/basistech/tclre/Utils.java
+++ b/src/test/java/com/basistech/tclre/Utils.java
@@ -16,12 +16,19 @@
 
 package com.basistech.tclre;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.EnumSet;
 import java.util.regex.Pattern;
 
 import org.hamcrest.Description;
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Assert;
 
@@ -56,7 +63,7 @@ public class Utils {
         }
     }
 
-    public static class Matches extends TypeSafeMatcher<String> {
+    public static class Matches extends TypeSafeDiagnosingMatcher<String> {
         final RePattern pattern;
         final EnumSet<ExecFlags> eflags;
         final String[] captures;
@@ -85,9 +92,36 @@ public class Utils {
         }
 
         @Override
-        public boolean matchesSafely(String input) {
-            ReMatcher matcher = pattern.matcher(input, eflags);
+        protected boolean matchesSafely(String input, Description mismatchDescription) {
+            RePattern rehydratedPattern;
+            if (innerMatcher(pattern, input, mismatchDescription, "normal")) {
+                try {
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    ObjectOutputStream oos = new ObjectOutputStream(baos);
+                    oos.writeObject(pattern);
+                    oos.close();
+                    ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+                    rehydratedPattern = (RePattern) ois.readObject();
+                } catch (Exception e) {
+                    mismatchDescription.appendText("Exception serializing or deserializing");
+                    mismatchDescription.appendValue(e);
+                    StringWriter sw = new StringWriter();
+                    PrintWriter pw = new PrintWriter(sw);
+                    e.printStackTrace(pw);
+                    pw.flush();
+                    mismatchDescription.appendText(sw.toString());
+                    return false;
+                }
+                return innerMatcher(rehydratedPattern, input, mismatchDescription, "serialized and deserialized");
+            } else {
+                return false;
+            }
+        }
+
+        private boolean innerMatcher(RePattern thePattern, String input, Description mismatchDescription, String note) {
+            ReMatcher matcher = thePattern.matcher(input, eflags);
             if (!matcher.find()) {
+                mismatchDescription.appendText("No match.");
                 return false; //<soap>no</soap>
             }
             if (captures == null) {
@@ -95,11 +129,13 @@ public class Utils {
             }
             int nGroups = captures.length;
             if (matcher.groupCount() != nGroups) {
+                mismatchDescription.appendText(String.format("Group count mismatches: was %d should be %d. (%s)", matcher.groupCount(), nGroups, note));
                 return false;
             }
             for (int i = 0; i < nGroups; i++) {
                 String mgroup = matcher.group(i + 1);
                 if (!(mgroup.equals(captures[i]))) {
+                    mismatchDescription.appendText(String.format("Capture %d mismatch: was %s should be %s. (%s)", i, mgroup, captures[i], note));
                     return false;
                 }
             }
@@ -175,5 +211,7 @@ public class Utils {
             }
             return new Matches(pattern, captures, flagSet, EnumSet.noneOf(ExecFlags.class));
         }
+
+
     }
 }

--- a/src/test/java/com/basistech/tclre/osgitest/OsgiBundleIT.java
+++ b/src/test/java/com/basistech/tclre/osgitest/OsgiBundleIT.java
@@ -1,0 +1,109 @@
+/******************************************************************************
+ ** This data and information is proprietary to, and a valuable trade secret
+ ** of, Basis Technology Corp.  It is given in confidence by Basis Technology
+ ** and may only be used as permitted under the license agreement under which
+ ** it has been distributed, and in no other way.
+ **
+ ** Copyright (c) 2014 Basis Technology Corporation All rights reserved.
+ **
+ ** The technical data and information provided herein are provided with
+ ** `limited rights', and the computer software provided herein is provided
+ ** with `restricted rights' as those terms are defined in DAR and ASPR
+ ** 7-104.9(a).
+ ******************************************************************************/
+
+package com.basistech.tclre.osgitest;
+
+import com.basistech.tclre.HsrePattern;
+import com.basistech.tclre.PatternFlags;
+import com.basistech.tclre.RePattern;
+import com.basistech.tclre.Utils;
+import com.google.common.collect.Lists;
+import com.google.common.io.Resources;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.provision;
+import static org.ops4j.pax.exam.CoreOptions.systemPackages;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+
+/**
+ * Test that the OSGi bundle works.
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class OsgiBundleIT extends Utils {
+
+    private String getDependencyVersion(String groupId, String artifactId) {
+        URL depPropsUrl = Resources.getResource("META-INF/maven/dependencies.properties");
+        Properties depProps = new Properties();
+        try {
+            depProps.load(Resources.asByteSource(depPropsUrl).openStream());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return (String)depProps.get(String.format("%s/%s/version", groupId, artifactId));
+    }
+
+    @Configuration
+    public Option[] config() {
+        String projectBuildDirectory = System.getProperty("project.build.directory");
+        String projectVersion = System.getProperty("project.version");
+
+        List<String> bundleUrls = Lists.newArrayList();
+        File bundleDir = new File(projectBuildDirectory, "bundles");
+        File[] bundleFiles = bundleDir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith(".jar");
+            }
+        });
+        for (File bundleFile : bundleFiles) {
+            try {
+                bundleUrls.add(bundleFile.toURI().toURL().toExternalForm());
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        bundleUrls.add(String.format("file:%s/tcl-regex-%s.jar", projectBuildDirectory, projectVersion));
+
+        String[] bundles = bundleUrls.toArray(new String[bundleUrls.size()]);
+        return options(
+                provision(bundles),
+                systemPackages(
+                        // These are needed for guava.
+                        "sun.misc",
+                        "javax.annotation",
+                        String.format("org.slf4j;version=\"%s\"", getDependencyVersion("org.slf4j", "slf4j-api"))
+
+                ),
+                junitBundles(),
+                systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("WARN")
+        );
+    }
+
+    @Test
+    public void onceOver() throws Exception {
+        // using ranges ensures that the ICU4J connection works right.
+        RePattern exp = HsrePattern.compile("[^a][\u4e00-\uf000][[:upper:]][^\ufeff][\u4e00-\u4e10]b.c.d",
+                PatternFlags.ADVANCED, PatternFlags.EXPANDED);
+        assertTrue(exp.matcher("Q\u4e01A$\u4e09bGcHd").matches());
+    }
+}


### PR DESCRIPTION
This pull request dissects the code so that the all the data used to execute a regular expression is in a set of immutable classes pulled out of the mutable classes used in compilation. The 'Pattern' object looks to the Guts object to store the business end of all of this, and the Guts object is now all immutable. This should facilitate making HsrePattern serializable. It probably does not repair any thread-safety bugs, since I don't know of a code path that would reuse and of the pieces once the compiler is finished compiling them.