### PR TITLE
Support data and patterns with SMP characters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tcl-regex</artifactId>
     <groupId>com.basistech.tclre</groupId>
-    <version>0.12.1-SNAPSHOT</version>
+    <version>0.13.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Java port of the regex engine from Tcl</description>
     <parent>

--- a/src/main/java/com/basistech/tclre/Compiler.java
+++ b/src/main/java/com/basistech/tclre/Compiler.java
@@ -366,21 +366,6 @@ class Compiler {
     }
 
     /**
-     * findarc - find arc, if any, from given source with given type and color
-     * If there is more than one such arc, the result is random.
-     */
-    Arc findarc(State s, int type, short co) {
-        Arc a;
-
-        for (a = s.outs; a != null; a = a.outchain) {
-            if (a.type == type && a.co == co) {
-                return a;
-            }
-        }
-        return null;
-    }
-
-    /**
      * - cparc - allocate a new arc within an NFA, copying details from old one
      * ^ static VOID cparc(struct nfa *, struct arc *, struct state *,
      * ^    struct state *);
@@ -407,34 +392,6 @@ class Compiler {
         }
         assert old.nins == 0;
         assert old.ins == null;
-    }
-
-    /**
-     * copyins - copy all in arcs of a state to another state
-     */
-    void copyins(Nfa nfa, State old, State newState) {
-        Arc a;
-
-        assert old != newState;
-
-        for (a = old.ins; a != null; a = a.inchain) {
-            cparc(nfa, a, a.from, newState);
-        }
-    }
-
-    /**
-     * moveouts - move all out arcs of a state to another state
-     * ^ static VOID moveouts(struct nfa *, struct state *, struct state *);
-     */
-    void moveouts(Nfa nfa, State old, State newState) {
-        Arc a;
-
-        assert old != newState;
-
-        while ((a = old.outs) != null) {
-            cparc(nfa, a, newState, a.to);
-            nfa.freearc(a);
-        }
     }
 
     /**
@@ -632,7 +589,7 @@ class Compiler {
         if (!see(stopper)) {
             assert stopper == ')' && see(EOS);
             //ERR(REG_EPAREN);
-            throw new RegexException("REG_EPAREN");
+            throw new RegexException("Unbalanced parentheses.");
         }
 
     /* optimize out simple cases */
@@ -1176,7 +1133,7 @@ class Compiler {
         }
 
         if (see(DIGIT) || n > DUPMAX) {
-            throw new RegexException("REG_BADBR");
+            throw new RegexException("Unvalid reference number.");
         }
         return n;
     }

--- a/src/main/java/com/basistech/tclre/Constants.java
+++ b/src/main/java/com/basistech/tclre/Constants.java
@@ -20,13 +20,6 @@ package com.basistech.tclre;
  * Some constants.
  */
 final class Constants {
-    static final int CHRBITS = 16;
-    static final int CHR_MIN = 0;
-    static final int CHR_MAX = 0xffff;
-    static final int BYTBITS = 8;
-    static final int BYTTAB = 1 << BYTBITS;
-    static final int BYTMASK = BYTTAB - 1;
-    static final int NBYTS = (CHRBITS + BYTBITS - 1) / BYTBITS;
     static final short COLORLESS = -1;
     static final short NOSUB = COLORLESS;
     static final short WHITE = 0;

--- a/src/main/java/com/basistech/tclre/Dfa.java
+++ b/src/main/java/com/basistech/tclre/Dfa.java
@@ -206,8 +206,9 @@ class Dfa {
             char theChar = hsreMatcher.data.charAt(cp - 1);
             if (Character.isLowSurrogate(theChar)) {
                 // collect the other end of the surrogate.
-                char low = theChar = hsreMatcher.data.charAt(cp - 2);
-                co = cm.getcolor(low, theChar); // and get a color for the pair.
+                char high = theChar = hsreMatcher.data.charAt(cp - 2);
+                int codepoint = Character.toCodePoint(high, theChar);
+                co = cm.getcolor(codepoint); // and get a color for the pair.
             } else {
                 co = cm.getcolor(theChar);
             }
@@ -224,7 +225,8 @@ class Dfa {
             char theChar = hsreMatcher.data.charAt(cp);
             int increment = 1;
             if (Character.isHighSurrogate(theChar)) {
-                co = cm.getcolor(theChar, hsreMatcher.data.charAt(cp + 1));
+                int codepoint = Character.toCodePoint(theChar, hsreMatcher.data.charAt(cp + 1));
+                co = cm.getcolor(codepoint);
                 increment = 2;
             } else {
                 co = cm.getcolor(theChar);
@@ -304,7 +306,8 @@ class Dfa {
             /* Not at bos at all, set color based on prior character. */
             char theChar = hsreMatcher.data.charAt(cp - 1);
             if (Character.isLowSurrogate(theChar)) {
-                co = cm.getcolor(hsreMatcher.data.charAt(cp - 2), theChar);
+                int codepoint = Character.toCodePoint(hsreMatcher.data.charAt(cp - 2), theChar);
+                co = cm.getcolor(codepoint);
             } else {
                 co = cm.getcolor(theChar);
             }
@@ -323,7 +326,8 @@ class Dfa {
             int increment = 1;
             char theChar = hsreMatcher.data.charAt(cp);
             if (Character.isHighSurrogate(theChar)) {
-                co = cm.getcolor(theChar, hsreMatcher.data.charAt(cp + 1));
+                int codepoint = Character.toCodePoint(theChar,  hsreMatcher.data.charAt(cp + 1));
+                co = cm.getcolor(codepoint);
                 increment = 2;
             } else {
                 co = cm.getcolor(theChar);

--- a/src/main/java/com/basistech/tclre/Dfa.java
+++ b/src/main/java/com/basistech/tclre/Dfa.java
@@ -267,7 +267,15 @@ class Dfa {
             }
         }
         if (post != -1) {       /* found one */
-            return post - 1;
+            /* Post points after the codepoint after the last one in the match (!) */
+            /* So, if that is an SMP codepoint, we need to back up 2 to get to the beginning of it,
+             * and thus be just after the last character of the match. */
+            char postChar = hsreMatcher.data.charAt(post - 1);
+            if (Character.isLowSurrogate(postChar)) {
+                return post - 2;
+            } else {
+                return post - 1;
+            }
         }
         return -1;
     }

--- a/src/main/java/com/basistech/tclre/Flags.java
+++ b/src/main/java/com/basistech/tclre/Flags.java
@@ -50,7 +50,6 @@ final class Flags {
     static final int REG_UBBS = 000100;
     static final int REG_UNONPOSIX = 000200;
     static final int REG_UUNSPEC = 000400;
-    static final int REG_UUNPORT = 001000;
     static final int REG_ULOCALE = 002000;
     static final int REG_UEMPTYMATCH = 004000;
     static final int REG_UIMPOSSIBLE = 010000;

--- a/src/main/java/com/basistech/tclre/Locale.java
+++ b/src/main/java/com/basistech/tclre/Locale.java
@@ -216,7 +216,7 @@ final class Locale {
      * This is a shortcut, preferably an efficient one, for simple characters;
      * messy cases are done via range().
      */
-    static UnicodeSet allcases(char c) {
+    static UnicodeSet allcases(int c) {
         UnicodeSet set = new UnicodeSet();
         set.add(c);
         set.closeOver(UnicodeSet.ADD_CASE_MAPPINGS);

--- a/src/main/java/com/basistech/tclre/RegMatch.java
+++ b/src/main/java/com/basistech/tclre/RegMatch.java
@@ -19,7 +19,7 @@ package com.basistech.tclre;
 import com.google.common.base.Objects;
 
 /**
- * Created by benson on 6/5/14.
+ * Store information about a capturing pattern.
  */
 class RegMatch {
     final int start;

--- a/src/main/java/com/basistech/tclre/RuntimeColorMap.java
+++ b/src/main/java/com/basistech/tclre/RuntimeColorMap.java
@@ -83,21 +83,17 @@ class RuntimeColorMap implements Serializable {
     }
 
     /**
-     * Return a color for a surrogate pair.
-     * @param c1 high surrogate
-     * @param c2 low surrogate
-     * @return a color for the resulting codepoint.
+     * Retrieve the color for a full codepoint.
+     * @param codepoint
+     * @return
      */
-    short getcolor(char c1, char c2) {
-        int codepoint = Character.toCodePoint(c1, c2);
+    short getcolor(int codepoint) {
         try {
             return fullMap.get(codepoint);
         } catch (NullPointerException npe) {
-            throw new RuntimeException(String.format("Pair %04x %04x -> CP %08x no mapping", (int)c1, (int)c2, codepoint));
+            throw new RuntimeException(String.format(" CP %08x no mapping", codepoint));
         }
     }
-
-
 
     private void writeObject(ObjectOutputStream stream) throws IOException {
         // TreeRangeMap is not Serializable.

--- a/src/main/java/com/basistech/tclre/RuntimeColorMap.java
+++ b/src/main/java/com/basistech/tclre/RuntimeColorMap.java
@@ -52,6 +52,21 @@ class RuntimeColorMap implements Serializable {
         return data[c];
     }
 
+    /**
+     * Return a color for a surrogate pair.
+     * @param c1
+     * @param c2
+     * @return
+     */
+    short getcolor(char c1, char c2) {
+        int codepoint = Character.toCodePoint(c1, c2);
+        if (codepoint <= Character.MAX_VALUE) {
+            return data[codepoint];
+        } else {
+            return Constants.WHITE; // for now, surrogates aren't covered by any color.
+        }
+    }
+
     /*
      * Avoid reading and writing 2^16 shorts by turning it into a sparse data structure.
      */

--- a/src/main/java/com/basistech/tclre/RuntimeColorMap.java
+++ b/src/main/java/com/basistech/tclre/RuntimeColorMap.java
@@ -19,7 +19,6 @@ package com.basistech.tclre;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
-import com.google.common.collect.Sets;
 import com.google.common.collect.TreeRangeMap;
 
 import java.io.IOException;

--- a/src/main/java/com/basistech/tclre/RuntimeColorMap.java
+++ b/src/main/java/com/basistech/tclre/RuntimeColorMap.java
@@ -16,12 +16,18 @@
 
 package com.basistech.tclre;
 
-import it.unimi.dsi.fastutil.chars.Char2ShortArrayMap;
-import it.unimi.dsi.fastutil.chars.Char2ShortMap;
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.TreeRangeMap;
 
 import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Immutable, sharable, color map.
@@ -31,68 +37,98 @@ import java.lang.reflect.Field;
  * we could use an Short2ShortOpenHashMap instead.
   */
 class RuntimeColorMap implements Serializable {
-    static final long serialVersionUID = 1L;
-    /* A somewhat sparse representation. */
-    private final short[] data;
+    static final long serialVersionUID = 2L;
+    /* for the BMP, we have this array */
+    private final transient short[] bmpMap;
+    private final RangeMap<Integer, Short> fullMap;
 
     /**
-     * Construct over a tree. It is the caller's responsibility to make an immutable copy.
-     * @param data -- the map as built in {@link com.basistech.tclre.ColorMap}
+     * Make a runtime color map. It might be sensible for the BMP optimization
+     * to be saved someplace and not recomputed here.
+     * @param fullMap -- the map as built in {@link com.basistech.tclre.ColorMap}
      */
-    RuntimeColorMap(short[] data) {
-        this.data = data;
+    RuntimeColorMap(RangeMap<Integer, Short> fullMap) {
+        this.fullMap = fullMap;
+        this.bmpMap = new short[Character.MAX_VALUE + 1];
+        computeBmp(fullMap);
+    }
+
+    private void computeBmp(RangeMap<Integer, Short> fullMap) {
+        for (Map.Entry<Range<Integer>, Short> me : fullMap.asMapOfRanges().entrySet()) {
+            Range<Integer> range = me.getKey();
+            int min = range.lowerEndpoint();
+            if (range.lowerBoundType() == BoundType.OPEN) {
+                min++;
+            }
+            if (min < Character.MAX_VALUE) {
+                int rmax = range.upperEndpoint();
+                if (range.upperBoundType() == BoundType.OPEN) {
+                    rmax--;
+                }
+                int max = Math.min(Character.MAX_VALUE, rmax);
+                for (int x = min; x <= max; x++) {
+                    this.bmpMap[x] = me.getValue();
+                }
+            }
+        }
     }
 
     /**
      * Retrieve the color for a character.
-     * @param c
-     * @return
+     * @param c a character (BMP)
+     * @return the color
      */
     short getcolor(char c) {
-        return data[c];
+        return bmpMap[c];
     }
 
     /**
      * Return a color for a surrogate pair.
-     * @param c1
-     * @param c2
-     * @return
+     * @param c1 high surrogate
+     * @param c2 low surrogate
+     * @return a color for the resulting codepoint.
      */
     short getcolor(char c1, char c2) {
         int codepoint = Character.toCodePoint(c1, c2);
-        if (codepoint <= Character.MAX_VALUE) {
-            return data[codepoint];
-        } else {
-            return Constants.WHITE; // for now, surrogates aren't covered by any color.
+        try {
+            return fullMap.get(codepoint);
+        } catch (NullPointerException npe) {
+            throw new RuntimeException(String.format("Pair %04x %04x -> CP %08x no mapping", (int)c1, (int)c2, codepoint));
         }
     }
 
-    /*
-     * Avoid reading and writing 2^16 shorts by turning it into a sparse data structure.
-     */
-    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
-        Char2ShortMap map = new Char2ShortArrayMap();
-        map.defaultReturnValue((short)0);
-        for (int x = 0; x <= Character.MAX_VALUE; x++) {
-            if (data[x] != 0) {
-                map.put((char)x, data[x]);
-            }
+
+
+    private void writeObject(ObjectOutputStream stream) throws IOException {
+        // TreeRangeMap is not Serializable.
+        Set<Map.Entry<Range<Integer>, Short>> entries = fullMap.asMapOfRanges().entrySet();
+        stream.writeInt(entries.size());
+        for (Map.Entry<Range<Integer>, Short> me : entries) {
+            stream.writeObject(me.getKey());
+            stream.writeShort(me.getValue());
         }
-        out.writeObject(map);
     }
+
+    @SuppressWarnings("unchecked")
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
         try {
-            Field dataField = RuntimeColorMap.class.getDeclaredField("data");
+            Field dataField = RuntimeColorMap.class.getDeclaredField("bmpMap");
             dataField.setAccessible(true);
             dataField.set(this, new short[Character.MAX_VALUE + 1]);
+            dataField = RuntimeColorMap.class.getDeclaredField("fullMap");
+            dataField.setAccessible(true);
+            dataField.set(this, TreeRangeMap.create());
         } catch (NoSuchFieldException e) {
             throw new RuntimeException(e);
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }
-        Char2ShortMap map = (Char2ShortMap) in.readObject();
-        for (char c : map.keySet()) {
-            data[c] = map.get(c); // thank goodness that Java doesn't have actual immutable arrays.
+        int count = in.readInt();
+        for (int x = 0; x < count; x ++) {
+            Range<Integer> k = (Range<Integer>) in.readObject();
+            short v = in.readShort();
+            fullMap.put(k, v);
         }
+        computeBmp(fullMap);
     }
 }

--- a/src/test/java/apitests/MatcherTest.java
+++ b/src/test/java/apitests/MatcherTest.java
@@ -137,6 +137,17 @@ public class MatcherTest extends Assert {
         }
     }
 
+    @Test
+    public void iterationWithSmp() throws Exception {
+        RePattern pattern = HsrePattern.compile("\uD800\uDF80", PatternFlags.ADVANCED);
+        ReMatcher matcher = pattern.matcher("\uD800\uDF80.\uD800\uDF80.\uD800\uDF80.\uD800\uDF80.\uD800\uDF80.\uD800\uDF80");
+        for (int x = 0; x < 6; x++) {
+            assertTrue(matcher.find());
+            assertEquals("start for iteration " + x, x * 3, matcher.start());
+            assertEquals("end for iteration " + x, (x * 3) + 2, matcher.end());
+        }
+    }
+
     /*
     adjacencyRule with "^\s{0,5}"
 adjacencyLength = 0

--- a/src/test/java/apitests/MatcherTest.java
+++ b/src/test/java/apitests/MatcherTest.java
@@ -170,6 +170,17 @@ public class MatcherTest extends Assert {
         }
     }
 
+    @Test
+    public void iterationWithSmpResumeNonGreedy() throws Exception {
+        RePattern pattern = HsrePattern.compile("x+?", PatternFlags.ADVANCED);
+        ReMatcher matcher = pattern.matcher("x\uD802\uDC40x\uD802\uDC40x\uD802\uDC40x\uD802\uDC40x\uD802\uDC40x");
+        for (int x = 0; x < 6; x++) {
+            assertTrue(matcher.find());
+            assertEquals("start for iteration " + x, x * 3, matcher.start());
+            assertEquals("end for iteration " + x, (x * 3) + 1, matcher.end());
+        }
+    }
+
     /*
       adjacencyRule with "^\s{0,5}"
       adjacencyLength = 0

--- a/src/test/java/apitests/MatcherTest.java
+++ b/src/test/java/apitests/MatcherTest.java
@@ -148,15 +148,36 @@ public class MatcherTest extends Assert {
         }
     }
 
+    @Test
+    public void iterationWithSmpAndSmpResume() throws Exception {
+        RePattern pattern = HsrePattern.compile("\uD800\uDF80", PatternFlags.ADVANCED);
+        ReMatcher matcher = pattern.matcher("\uD800\uDF80\uD802\uDC40\uD800\uDF80\uD802\uDC40\uD800\uDF80\uD802\uDC40\uD800\uDF80\uD802\uDC40\uD800\uDF80\uD802\uDC40\uD800\uDF80");
+        for (int x = 0; x < 6; x++) {
+            assertTrue(matcher.find());
+            assertEquals("start for iteration " + x, x * 4, matcher.start());
+            assertEquals("end for iteration " + x, (x * 4) + 2, matcher.end());
+        }
+    }
+
+    @Test
+    public void iterationWithSmpResume() throws Exception {
+        RePattern pattern = HsrePattern.compile("x", PatternFlags.ADVANCED);
+        ReMatcher matcher = pattern.matcher("x\uD802\uDC40x\uD802\uDC40x\uD802\uDC40x\uD802\uDC40x\uD802\uDC40x");
+        for (int x = 0; x < 6; x++) {
+            assertTrue(matcher.find());
+            assertEquals("start for iteration " + x, x * 3, matcher.start());
+            assertEquals("end for iteration " + x, (x * 3) + 1, matcher.end());
+        }
+    }
+
     /*
-    adjacencyRule with "^\s{0,5}"
-adjacencyLength = 0
+      adjacencyRule with "^\s{0,5}"
+      adjacencyLength = 0
 
-then, matchExact is called:
+      then, matchExact is called:
 
-matchExact(null, buffer, offset, 0) <== 0 length
+        matchExact(null, buffer, offset, 0) <== 0 length
      */
-
     @Test
     public void zeroLengthInput() throws Exception {
         RePattern pattern = HsrePattern.compile("^\\s{0,5}");

--- a/src/test/java/com/basistech/tclre/LexTest.java
+++ b/src/test/java/com/basistech/tclre/LexTest.java
@@ -125,7 +125,7 @@ public class LexTest extends Utils{
         exp = HsrePattern.compile("\\cC\\B\\w\\D\\S\\W", PatternFlags.ADVANCED);
         assertThat("\u0003\\_!$@", matches(exp));
 
-        exp = HsrePattern.compile("[\\uABCD][\\uEF89][\\U12345678]?", PatternFlags.ADVANCED);
+        exp = HsrePattern.compile("[\\uABCD][\\uEF89][\\U0001039F]?", PatternFlags.ADVANCED);
         assertThat("\uABCD\uEF89", matches(exp));
         HsrePattern.compile(".*[[:<:]].*[[:>:]].*", PatternFlags.ADVANCED);
         /* TODO:This works against C++, but doesn't work here. It's deprecated, though. */

--- a/src/test/java/com/basistech/tclre/RangeTest.java
+++ b/src/test/java/com/basistech/tclre/RangeTest.java
@@ -35,8 +35,6 @@ public class RangeTest extends Utils {
         assertThat("Q\u4e01A$\u4e09bGcHd", matches(exp));
     }
 
-
-
     @Test
     public void testNegativeRange() throws Exception {
         RePattern exp = HsrePattern.compile("[^a]", PatternFlags.ADVANCED, PatternFlags.EXPANDED);

--- a/src/test/java/com/basistech/tclre/SmpTest.java
+++ b/src/test/java/com/basistech/tclre/SmpTest.java
@@ -1,0 +1,34 @@
+/******************************************************************************
+ ** This data and information is proprietary to, and a valuable trade secret
+ ** of, Basis Technology Corp.  It is given in confidence by Basis Technology
+ ** and may only be used as permitted under the license agreement under which
+ ** it has been distributed, and in no other way.
+ **
+ ** Copyright (c) 2015 Basis Technology Corporation All rights reserved.
+ **
+ ** The technical data and information provided herein are provided with
+ ** `limited rights', and the computer software provided herein is provided
+ ** with `restricted rights' as those terms are defined in DAR and ASPR
+ ** 7-104.9(a).
+ ******************************************************************************/
+
+package com.basistech.tclre;
+
+import org.junit.Test;
+
+import static com.basistech.tclre.Utils.Matches.matches;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Characters outside the SMP (woo-woo)
+ */
+public class SmpTest {
+    @Test
+    public void testSingleCharMatch() throws Exception {
+        assertThat("b\uD800\uDF80c", matches("b.c", PatternFlags.BASIC));
+        assertThat("bxyc", not(matches("b.c", PatternFlags.BASIC)));
+        assertThat("\uD800\uDF80b", matches(".b", PatternFlags.BASIC));
+        assertThat("b\uD800\uDF80", matches("b.", PatternFlags.BASIC));
+    }
+}

--- a/src/test/java/com/basistech/tclre/SmpTest.java
+++ b/src/test/java/com/basistech/tclre/SmpTest.java
@@ -31,4 +31,12 @@ public class SmpTest {
         assertThat("\uD800\uDF80b", matches(".b", PatternFlags.BASIC));
         assertThat("b\uD800\uDF80", matches("b.", PatternFlags.BASIC));
     }
+
+    @Test
+    public void smpPattern() throws Exception {
+        assertThat("b", not(matches("\uD800\uDF80", PatternFlags.BASIC)));
+        assertThat("b\uD800\uDF80", not(matches(".\uD800\uDF80", PatternFlags.BASIC)));
+        // This syntax doesn't work, because we don't let ICU parse inside the brackets.
+        assertThat("\uD800\uDF80", matches("[\\U00010380-\\U0001039F]", PatternFlags.ADVANCED));
+    }
 }

--- a/src/test/java/com/basistech/tclre/SmpTest.java
+++ b/src/test/java/com/basistech/tclre/SmpTest.java
@@ -38,6 +38,7 @@ public class SmpTest {
         assertThat("b", not(matches("\uD800\uDF80", PatternFlags.BASIC)));
         assertThat("b\uD800\uDF80", matches(".\uD800\uDF80", PatternFlags.BASIC));
         assertThat("\uD800\uDF80", matches("[\\U00010380-\\U0001039F]", PatternFlags.ADVANCED));
+        assertThat("\uD800\uDF80", matches("[\uD800\uDF80-\uD800\uDF8F]", PatternFlags.ADVANCED));
     }
 
     @Test

--- a/src/test/java/com/basistech/tclre/SmpTest.java
+++ b/src/test/java/com/basistech/tclre/SmpTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import static com.basistech.tclre.Utils.Matches.matches;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Characters outside the SMP (woo-woo)
@@ -35,8 +36,21 @@ public class SmpTest {
     @Test
     public void smpPattern() throws Exception {
         assertThat("b", not(matches("\uD800\uDF80", PatternFlags.BASIC)));
-        assertThat("b\uD800\uDF80", not(matches(".\uD800\uDF80", PatternFlags.BASIC)));
-        // This syntax doesn't work, because we don't let ICU parse inside the brackets.
+        assertThat("b\uD800\uDF80", matches(".\uD800\uDF80", PatternFlags.BASIC));
         assertThat("\uD800\uDF80", matches("[\\U00010380-\\U0001039F]", PatternFlags.ADVANCED));
+    }
+
+    @Test
+    public void findCharClass() throws Exception {
+        RePattern pattern = HsrePattern.compile("[\\U00010380]", PatternFlags.ADVANCED);
+        ReMatcher matcher = pattern.matcher("\uD800\uDF80.\uD800\uDF80.\uD800\uDF80.\uD800\uDF80.\uD800\uDF80.\uD800\uDF80");
+        assertTrue(matcher.find());
+    }
+
+    @Test
+    public void find() throws Exception {
+        RePattern pattern = HsrePattern.compile("\uD800\uDF80", PatternFlags.ADVANCED);
+        ReMatcher matcher = pattern.matcher("\uD800\uDF80.\uD800\uDF80.\uD800\uDF80.\uD800\uDF80.\uD800\uDF80.\uD800\uDF80");
+        assertTrue(matcher.find());
     }
 }


### PR DESCRIPTION
Juggle Java codepoints to handle both data and patterns with SMP characters. \U escapes and surrogate pairs in patterns should work about equivalently, but this isn't all tested yet.
