### PR TITLE
TEJ-1729: Jenkinsfile and SonarQube integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+env.project = "tcl-regex-java"
+
+standardProperties()
+
+def options = [:]
+
+options.afterBuild = {
+    withMaven([dk: params.testJdk]) {
+        withSonarQubeEnv() {
+            sh "mvn -D sonar.login=${env.SONAR_AUTH_TOKEN} sonar:sonar -D sonar.host.url=${env.SONAR_HOST_URL}"
+        }
+    }
+}
+
+standardBuildSteps(options)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,8 @@ properties([
     ])
 ])
 
+standardProperties(properties)
+
 def options = [:]
 
 options.afterBuild = {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,4 +23,6 @@ options.afterBuild = {
     }
 }
 
+options.buildArgs = ' '
+
 standardBuildSteps(options)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,15 @@
 env.project = "tcl-regex-java"
 
-standardProperties()
+properties([
+    parameters([
+        booleanParam(name: 'release',
+        defaultValue: false,
+        description: 'Release the project'),
+        string(name: 'version',
+        defaultValue: '',
+        description: 'Version to release, or empty to use the default next version')
+    ])
+])
 
 def options = [:]
 

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
-                      <argLine>-Xmx2g</argLine>
+                      <argLine>-Xmx2g @{argLine}</argLine>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.ops4j.pax.url</groupId>
+            <artifactId>pax-url-aether</artifactId>
+            <version>2.6.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.basistech</groupId>
             <artifactId>pax-exam-test-composite</artifactId>
             <version>0.0.11</version>


### PR DESCRIPTION
There was a bug in which the pax exam was trying to load a jar over http rather than https, and so I had to bump the version of pax-url-aether pulled in via pax-exam-test-composite to fix it.